### PR TITLE
adding PropTypes package

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "jsdom": "^8.1.0",
     "mocha": "^2.4.5",
     "nodemon": "^1.9.1",
+    "prop-types": "^15.5.10",
     "react": "^15.0.0",
     "react-addons-test-utils": "^15.0.0",
     "react-dom": "^15.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 
 import Wrap from './Wrap'
 // Stylized
@@ -61,12 +62,12 @@ class ContentLoader extends Component {
 }
 
 ContentLoader.propTypes = {
-    style: React.PropTypes.object,
-    type: React.PropTypes.string,
-    speed: React.PropTypes.number,
-    height: React.PropTypes.number,
-    primaryColor: React.PropTypes.string,
-    secondaryColor: React.PropTypes.string
+    style: PropTypes.object,
+    type: PropTypes.string,
+    speed: PropTypes.number,
+    height: PropTypes.number,
+    primaryColor: PropTypes.string,
+    secondaryColor: PropTypes.string
 }
 
 export default ContentLoader


### PR DESCRIPTION
This package are using a deprecated way of verifying component proptypes which causes a warning. I've Just added the new separated package for this purpose.