### PR TITLE
fix(build): amend invalid syntax that breaks the build

### DIFF
--- a/src/stylized/CodeStyle.js
+++ b/src/stylized/CodeStyle.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import Wrap from '../Wrap'
 
-const CodeStyle = props => 
-  return (
+const CodeStyle = props => {
+    return (
     <Wrap {...props}>
       <rect x="0" y="0" rx="3" ry="3" width="70" height="10" />
       <rect x="80" y="0" rx="3" ry="3" width="100" height="10" />


### PR DESCRIPTION
The build and `npm install` were breaking.

FYI, npm starts to put a deprecation message regarding `prepublish` scripts. 