### PR TITLE
Drop uuid dependency and use random string for ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,7 @@
     "react": "^16.1.1",
     "react-addons-test-utils": "^15.0.0",
     "react-dom": "^16.1.1",
-    "sinon": "^4.1.2",
-    "uuid": "^3.0.1"
+    "sinon": "^4.1.2"
   },
   "peerDependencies": {
     "react": "^15.6.1",

--- a/src/Wrap.js
+++ b/src/Wrap.js
@@ -1,6 +1,5 @@
 //@flow
 import * as React from 'react'
-import uuid from 'uuid'
 
 import type { Props as ContentLoaderProps } from './index'
 
@@ -8,9 +7,14 @@ export type WrapProps = {
   children?: React.ChildrenArray<*>,
 } & ContentLoaderProps
 
+const randomId = () =>
+  Math.random()
+    .toString(36)
+    .substr(2, 9)
+
 const Wrap = (props: WrapProps): React.Element<*> => {
-  let idClip = uuid.v1()
-  let idGradient = uuid.v1()
+  let idClip = randomId()
+  let idGradient = randomId()
 
   return (
     <svg

--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,6 @@ ContentLoader.defaultProps = {
   secondaryColor: '#e0e0e0',
   preserveAspectRatio: 'xMidYMid meet',
   className: '',
-};
+}
 
 export default ContentLoader

--- a/yarn.lock
+++ b/yarn.lock
@@ -6281,7 +6281,7 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
 
-uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
+uuid@^3.0.0, uuid@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 


### PR DESCRIPTION
I'd like to remove the uuid dependency. It adds about 1kb gzip to the package, but we can generate unique enough strings with Math.random.

If you would like to keep the dependency on uuid, then it should be specified under dependencies in package.json instead of devDependencies.

---

Note that I only changed the `yarn.lock` as when I used npm there were significant changes to the `package-lock.json`, so I think it is out of sync and yarn is the source of truth.