### PR TITLE
Change peerDeps to allow React 15/16 and remove react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
     "uuid": "^3.0.1"
   },
   "peerDependencies": {
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+    "react": "^15.0.0-0 || ^16.0.0-0"
   },
   "dependencies": {
     "babel-runtime": "^6.6.1"


### PR DESCRIPTION
In #64 it was asked why your peerDependency of React was 16, so in https://github.com/danilowoz/react-content-loader/commit/f6b386bcddcd24e89b0002877f92799672bb0197 you changed it to a very specific version of React 15.

The thing about peerDependencies is they aren't enforced by anything and you just receive a warning if the package you specify is not found in the person's package.json or is not in the correct range.

I took the time to setup some CodeSandboxes to ensure that this package works fine on both React 15 and 16, so there is no real reason not to show support for that in the peerDependency field.

React 15: https://codesandbox.io/s/j392mynz45
React 16: https://codesandbox.io/s/pmp4x3x0kx