### PR TITLE
Move babel-runtime from dependency to devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "babel-preset-flow": "^6.23.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-2": "^6.5.0",
+    "babel-runtime": "^6.6.1",
     "chai": "^4.1.2",
     "chai-enzyme": "^1.0.0-beta.0",
     "enzyme": "^3.2.0",
@@ -67,8 +68,5 @@
   "peerDependencies": {
     "react": "^15.6.1",
     "react-dom": "^15.6.1"
-  },
-  "dependencies": {
-    "babel-runtime": "^6.6.1"
   }
 }


### PR DESCRIPTION
This dependency is not needed at runtime, only for development and building the package before publishing to npm.