### PR TITLE
Added `uniquekey` a defaultProp

### DIFF
--- a/src/Wrap.js
+++ b/src/Wrap.js
@@ -1,6 +1,5 @@
 //@flow
 import * as React from 'react'
-import uid from './uid'
 
 import type { Props as ContentLoaderProps } from './index'
 
@@ -9,8 +8,8 @@ export type WrapProps = {
 } & ContentLoaderProps
 
 const Wrap = (props: WrapProps): React.Element<*> => {
-  const idClip = `${props.uniquekey}-idClip` || uid()
-  const idGradient = `${props.uniquekey}-idGradient` || uid()
+  const idClip = `${props.uniquekey}-idClip`
+  const idGradient = `${props.uniquekey}-idGradient`
 
   return (
     <svg

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 //@flow
 import * as React from 'react'
 import Wrap from './Wrap'
+import uid from './uid'
 
 // Stylized
 export { default as Facebook } from './stylized/FacebookStyle'
@@ -29,6 +30,7 @@ const defaultProps = {
   primaryColor: '#f0f0f0',
   secondaryColor: '#e0e0e0',
   preserveAspectRatio: 'xMidYMid meet',
+  uniquekey: uid(),
 }
 
 const InitialComponent = props => (

--- a/tests/index.js
+++ b/tests/index.js
@@ -71,5 +71,12 @@ describe('<ContentLoader />:', () => {
     it('`style` is a object and used', () => {
       expect(wrapper.props().style).to.deep.equal({ marginBottom: '10px' })
     })
+
+    it('`uniquekey` does not generate undefined `id` values for svg', () => {
+      const idClip = wrapper.find('clipPath').prop('id')
+      const idGradient = wrapper.find('linearGradient').prop('id')
+      expect(idClip).to.not.contain(undefined)
+      expect(idGradient).to.not.contain(undefined)
+    })
   })
 })


### PR DESCRIPTION
### What was happening
Using multiple, different custom loaders at one time resulted in the same loader being referenced and rendered. Identical `id`s were being sent to the svg, looking like this: `undefined-idClip` (see screenshot below).

### What was changed
The `uniquekey` prop has been added to `defaultProps` to prevent this behavior, resulting in unique `id`s for each loading component.

### Screenshots
#### Before
![before](https://user-images.githubusercontent.com/4238222/35710985-6a556b1a-076f-11e8-920b-9e2e0e99c92f.jpg)

#### After
![after](https://user-images.githubusercontent.com/4238222/35710990-6cac9474-076f-11e8-9998-16eb642c18cd.jpg)