### PR TITLE
Improve the source and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,8 @@ Npm: `$ npm i react-content-loader --save`
 
 ```jsx
 // import the component
+// and you can use them directly, such as <Facebook />, <ContentLoader />
 import ContentLoader, { Facebook } from 'react-content-loader'
-
-const MyLoader = () => <ContentLoader />
-const MyFacebookLoader = () => <Facebook />
 ```
 
 **Or in custom mode, using the
@@ -80,7 +78,7 @@ const MyLoader = () => (
 // import the component
 import { Facebook } from 'react-content-loader'
 
-const MyFacebookLoader = () => <Facebook />
+// Use it like a Component in your render function.
 ```
 
 ![Facebook Style](https://user-images.githubusercontent.com/4838076/34308760-ec55df82-e735-11e7-843b-2e311fa7b7d0.gif)
@@ -91,7 +89,7 @@ const MyFacebookLoader = () => <Facebook />
 // import the component
 import { Instagram } from 'react-content-loader'
 
-const MyInstagramLoader = () => <Instagram />
+// Use it like a Component in your render function.
 ```
 
 ![Instagram Style](https://cloud.githubusercontent.com/assets/4838076/22555637/749f9e26-e94b-11e6-84ff-83cd415c1eb9.gif)
@@ -102,7 +100,7 @@ const MyInstagramLoader = () => <Instagram />
 // import the component
 import { Code } from 'react-content-loader'
 
-const MyCodeLoader = () => <Code />
+// Use it like a Component in your render function.
 ```
 
 ![Code Style](https://cloud.githubusercontent.com/assets/4838076/22555473/effa54c2-e94a-11e6-9128-9b608bcc69d9.gif)
@@ -113,7 +111,7 @@ const MyCodeLoader = () => <Code />
 // import the component
 import { List } from 'react-content-loader'
 
-const MyListLoader = () => <List />
+// Use it like a Component in your render function.
 ```
 
 ![List Style](https://user-images.githubusercontent.com/2671660/27986068-7a0040d6-63f9-11e7-8e54-dcb220e42fd7.gif)
@@ -124,7 +122,7 @@ const MyListLoader = () => <List />
 // import the component
 import { BulletList } from 'react-content-loader'
 
-const MyBulletListLoader = () => <BulletList />
+// Use it like a Component in your render function.
 ```
 
 ![Bullet list Style](https://user-images.githubusercontent.com/4838076/31998372-59817bac-b96e-11e7-8ef8-07f61670ee18.gif)

--- a/src/Wrap.js
+++ b/src/Wrap.js
@@ -4,6 +4,16 @@ import * as React from 'react'
 import uid from './uid'
 import type { Props as ContentLoaderProps } from './index'
 
+export const defaultProps = {
+  animate: true,
+  speed: 2,
+  width: 400,
+  height: 130,
+  primaryColor: '#f0f0f0',
+  secondaryColor: '#e0e0e0',
+  preserveAspectRatio: 'xMidYMid meet',
+}
+
 export type WrapProps = {
   children?: React.ChildrenArray<*>,
 } & ContentLoaderProps
@@ -68,5 +78,6 @@ const Wrap = (props: WrapProps): React.Element<*> => {
     </svg>
   )
 }
+Wrap.defaultProps = defaultProps;
 
 export default Wrap

--- a/src/Wrap.js
+++ b/src/Wrap.js
@@ -4,16 +4,6 @@ import * as React from 'react'
 import uid from './uid'
 import type { Props as ContentLoaderProps } from './index'
 
-export const defaultProps = {
-  animate: true,
-  speed: 2,
-  width: 400,
-  height: 130,
-  primaryColor: '#f0f0f0',
-  secondaryColor: '#e0e0e0',
-  preserveAspectRatio: 'xMidYMid meet',
-}
-
 export type WrapProps = {
   children?: React.ChildrenArray<*>,
 } & ContentLoaderProps
@@ -78,6 +68,15 @@ const Wrap = (props: WrapProps): React.Element<*> => {
     </svg>
   )
 }
-Wrap.defaultProps = defaultProps;
+Wrap.defaultProps = {
+  animate: true,
+  speed: 2,
+  width: 400,
+  height: 130,
+  primaryColor: '#f0f0f0',
+  secondaryColor: '#e0e0e0',
+  preserveAspectRatio: 'xMidYMid meet',
+}
+
 
 export default Wrap

--- a/src/index.js
+++ b/src/index.js
@@ -23,25 +23,15 @@ export type Props = {
   uniquekey: string,
 }
 
-export const defaultProps = {
-  animate: true,
-  speed: 2,
-  width: 400,
-  height: 130,
-  primaryColor: '#f0f0f0',
-  secondaryColor: '#e0e0e0',
-  preserveAspectRatio: 'xMidYMid meet',
-}
 
 const InitialComponent = props => (
   <rect x="0" y="0" rx="5" ry="5" width={props.width} height={props.height} />
 )
 
 const ContentLoader = (props: Props) => {
-  const mergedProps = { ...defaultProps, ...props }
-  const children = props.children ? props.children : <InitialComponent {...mergedProps} />
+  const children = props.children || InitialComponent(props);
 
-  return <Wrap {...mergedProps}>{children}</Wrap>
+  return <Wrap {...props}>{children}</Wrap>
 }
 
 export default ContentLoader

--- a/src/index.js
+++ b/src/index.js
@@ -23,13 +23,12 @@ export type Props = {
   uniquekey: string,
 }
 
-
-const InitialComponent = props => (
-  <rect x="0" y="0" rx="5" ry="5" width={props.width} height={props.height} />
+const InitialComponent = ({ width = 400, height = 130 }) => (
+  <rect x="0" y="0" rx="5" ry="5" width={width} height={height} />
 )
 
 const ContentLoader = (props: Props) => {
-  const children = props.children || InitialComponent(props);
+  const children = props.children || InitialComponent(props)
 
   return <Wrap {...props}>{children}</Wrap>
 }

--- a/tests/Wrap.js
+++ b/tests/Wrap.js
@@ -13,10 +13,9 @@ chai.use(chaiEnzyme())
 
 import ContentLoader from '../src/index'
 import Wrap, { generateId } from '../src/Wrap'
-import defaultProps from '../src/Wrap'
 
 describe('<Wrap /> Check id`s to render the SVG', () => {
-  const wrapper = mount(<Wrap {...defaultProps} />)
+  const wrapper = mount(<Wrap />)
 
   it('is mask with the same `idClip`', () => {
     const idClip = wrapper.find('clipPath').prop('id')

--- a/tests/Wrap.js
+++ b/tests/Wrap.js
@@ -13,7 +13,7 @@ chai.use(chaiEnzyme())
 
 import ContentLoader from '../src/index'
 import Wrap, { generateId } from '../src/Wrap'
-import defaultProps from '../src/index'
+import defaultProps from '../src/Wrap'
 
 describe('<Wrap /> Check id`s to render the SVG', () => {
   const wrapper = mount(<Wrap {...defaultProps} />)


### PR DESCRIPTION
Hello! I found the update of v3 yesterday, it doesn't need to be used like below.
```jsx
import ContentLoader from 'react-content-loader'
const MyLoader = () => <ContentLoader type="facebook" />
```
**It's awesome!**

But the `README.md` didn't fit this way. Because We can use it just like
```jsx
<Facebook {...whatever} />
```
So I updated it.
And, I think the best place for `defaultProps` is the `Wrap.js`