### PR TITLE
fix(package.json): Format script was changed to work on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test:watch": "jest tests --watch",
     "tsc": "node_modules/.bin/tsc",
     "tsc:watch": "npm run tsc -- --watch",
-    "format": "prettier --write 'src/**/*.{ts,tsx}'",
+    "format": "prettier --write \"src/**/*.{ts,tsx}\"",
     "coverage": "codecov",
     "release": "semantic-release"
   },


### PR DESCRIPTION
## Summary
There is an issue with `prettier` command on windows which causes the command to fail, and `prettier` command is used in pre-commit command of project (`npm run format`). to fix this problem, `prettier` command should be run using double quotes instead of single quotes (see [this issue](https://github.com/prettier/prettier/issues/4804)).

## Checklist
- [] Are all the test cases passing?
- [] If any new feature has been added, then are the test cases updated/added?
- [] Has the documentation been updated for the proposed change, if required?