### PR TITLE
fix(svg): uses correct aria-* attribute for label

### DIFF
--- a/src/Svg.tsx
+++ b/src/Svg.tsx
@@ -35,7 +35,7 @@ export default ({
       role="img"
       style={{ ...style, ...rtlStyle }}
       className={className}
-      aria-labelledby={ariaLabel ? ariaLabel : null}
+      aria-label={ariaLabel ? ariaLabel : null}
       viewBox={`0 0 ${width} ${height}`}
       preserveAspectRatio={preserveAspectRatio}
       {...props}

--- a/src/__tests__/Svg.tests.tsx
+++ b/src/__tests__/Svg.tests.tsx
@@ -126,8 +126,8 @@ describe('Svg', () => {
     it('svg has aria-label', () => {
       const { svg } = partsOfComponent
 
-      expect(typeof svg.props['aria-labelledby']).toBe('string')
-      expect(svg.props['aria-labelledby'].length).not.toBe(0)
+      expect(typeof svg.props['aria-label']).toBe('string')
+      expect(svg.props['aria-label'].length).not.toBe(0)
     })
 
     it('svg has role', () => {

--- a/src/__tests__/stylized/__snapshots__/BulletListStyle.test.tsx.snap
+++ b/src/__tests__/stylized/__snapshots__/BulletListStyle.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`BulletListStyle renders correctly 1`] = `
 <svg
-  aria-labelledby="Loading interface..."
+  aria-label="Loading interface..."
   preserveAspectRatio="none"
   role="img"
   style={Object {}}

--- a/src/__tests__/stylized/__snapshots__/CodeStyle.test.tsx.snap
+++ b/src/__tests__/stylized/__snapshots__/CodeStyle.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CodeStyle renders correctly 1`] = `
 <svg
-  aria-labelledby="Loading interface..."
+  aria-label="Loading interface..."
   preserveAspectRatio="none"
   role="img"
   style={Object {}}

--- a/src/__tests__/stylized/__snapshots__/FacebookStyle.test.tsx.snap
+++ b/src/__tests__/stylized/__snapshots__/FacebookStyle.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`FacebookStyle renders correctly 1`] = `
 <svg
-  aria-labelledby="Loading interface..."
+  aria-label="Loading interface..."
   preserveAspectRatio="none"
   role="img"
   style={Object {}}

--- a/src/__tests__/stylized/__snapshots__/InstagramStyle.test.tsx.snap
+++ b/src/__tests__/stylized/__snapshots__/InstagramStyle.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`InstagramStyle renders correctly 1`] = `
 <svg
-  aria-labelledby="Loading interface..."
+  aria-label="Loading interface..."
   preserveAspectRatio="none"
   role="img"
   style={Object {}}

--- a/src/__tests__/stylized/__snapshots__/ListStyle.test.tsx.snap
+++ b/src/__tests__/stylized/__snapshots__/ListStyle.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ListStyle renders correctly 1`] = `
 <svg
-  aria-labelledby="Loading interface..."
+  aria-label="Loading interface..."
   preserveAspectRatio="none"
   role="img"
   style={Object {}}


### PR DESCRIPTION
## Summary
according to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute), the aria-labelledby attribute is reserved for one or more
element IDs to associate a label with an element. the aria-label attribute is for a string when no
visible label on the screen

[WAI-ARIA](https://www.w3.org/TR/wai-aria/#aria-labelledby) has this to say:

> If the interface is such that it is not possible to have a visible label on the screen, authors **_SHOULD_** use aria-label and **_SHOULD NOT_** use aria-labelledby. As required by the text alternative computation, user agents give precedence to aria-labelledby over aria-label when computing the accessible name property.

## Related Issue #[issue number]
This was introduced in #115, but (as far as I understand the aria-* attributes, slightly incorrectly).

## Any Breaking Changes
no

## Checklist
- [x] Are all the test cases passing?
- [x] If any new feature has been added, then are the test cases updated/added?
- [x] Has the documentation been updated for the proposed change, if required?