### PR TITLE
fix(native/svg.tsx): svg is truncated when using a ViewBox -react-native

### DIFF
--- a/src/native/Svg.tsx
+++ b/src/native/Svg.tsx
@@ -82,6 +82,7 @@ class NativeSvg extends Component<RequiredIContentLoaderProps, State> {
       width,
       rtl,
       style,
+      viewBox = `0 0 ${width} ${height}`,
       ...props
     } = this.props
 
@@ -91,6 +92,7 @@ class NativeSvg extends Component<RequiredIContentLoaderProps, State> {
 
     const rtlStyle = rtl ? { transform: [{ rotateY: '180deg' }] } : {}
     const composedStyle = Object.assign(style, rtlStyle)
+    const [_vbX, _vbY, vbWidth, vbHeight] = viewBox.split(' ')
 
     // Remove unnecessary keys
     delete props.id
@@ -99,7 +101,7 @@ class NativeSvg extends Component<RequiredIContentLoaderProps, State> {
 
     return (
       <Svg
-        viewBox={`0 0 ${width} ${height}`}
+        viewBox={viewBox}
         width={width}
         height={height}
         preserveAspectRatio="none"
@@ -109,8 +111,8 @@ class NativeSvg extends Component<RequiredIContentLoaderProps, State> {
         <Rect
           x="0"
           y="0"
-          width={width}
-          height={height}
+          width={parseInt(vbWidth)}
+          height={parseInt(vbHeight)}
           fill={`url(#${this.idClip})`}
           clipPath={`url(#${this.idGradient})`}
         />


### PR DESCRIPTION
## Summary
When providing the `width` `height` and `viewBox` props, the `<Rect>` component rendered by the
`NativeSvg` component cause the resulted svg to be truncated. This appends because this Rect
component takes the 'desired outer size' ( width and height ) while being *inside* the Svg's
Viewbox. So if the Svg's viewbox is '0 0 100 100' and `width={50}` the inner Rect will be half the
size of the final SVG (-> 25)

**Giving the following snippet**
```jsx
<Svg width={width} height={height} viewBox='0 0 636 566' preserveAspectRatio='align'>
      <Rect x='0' y='2' rx='4' ry='4' width='634' height='374' />
      <Rect x='12' y='404' rx='3' ry='3' width='259' height='18' />
      <Rect x='294' y='404' rx='3' ry='3' width='163' height='18' />
      <Rect x='12' y='441' rx='3' ry='3' width='575' height='18' />
      <Rect x='12' y='473' rx='3' ry='3' width='350' height='18' />
      <Rect x='70' y='523' rx='3' ry='3' width='251' height='18' />
      <Circle cx='37' cy='532' r='25' />
</Svg>
```
_This is the desired output using base `Svg` component from react-native-svg_
<img width="354" alt="Capture d’écran 2020-01-05 à 19 55 14" src="https://user-images.githubusercontent.com/9294168/71784635-c497d800-2ff5-11ea-9325-b73917a8d81a.png">


_When using `<ContentLoader/>` instead of `Svg`_
<img width="350" alt="Capture d’écran 2020-01-05 à 19 55 43" src="https://user-images.githubusercontent.com/9294168/71784638-c9f52280-2ff5-11ea-9831-463be840cf2f.png">

## Solution
I just replaced the width and height of the `Rect`component by the `viewBoxWidth`and the `viewBoxHeight`( vbWith & vbHeight ).
If no `viewBox` is provided, a default one is created using `width` and `height` exactly like it was before.

## Any Breaking Changes
No

## Checklist
- [x] Are all the test cases passing?
- <strike>If any new feature has been added, then are the test cases updated/added?</strike>
- <strike>Has the documentation been updated for the proposed change, if required?</strike>