### PR TITLE
fix(native): set the right initial value of the animation instance

### DIFF
--- a/src/native/Svg.tsx
+++ b/src/native/Svg.tsx
@@ -23,7 +23,7 @@ class NativeSvg extends Component<IContentLoaderProps> {
     style: {},
   }
 
-  animatedValue = new Animated.Value(0)
+  animatedValue = new Animated.Value(-1)
 
   fixedId = this.props.uniqueKey || uid()
 

--- a/src/native/__tests__/__snapshots__/snapshots.test.tsx.snap
+++ b/src/native/__tests__/__snapshots__/snapshots.test.tsx.snap
@@ -62,8 +62,8 @@ exports[`ContentLoader snapshots renders correctly the basic version 1`] = `
     </ClipPath>
     <LinearGradient
       id="snapshots-diff"
-      x1="-33.33333333333334%"
-      x2="66.66666666666666%"
+      x1="-100%"
+      x2="0%"
       y1={0}
       y2={0}
     >
@@ -146,8 +146,8 @@ exports[`ContentLoader snapshots renders correctly with viewBox defined 1`] = `
     </ClipPath>
     <LinearGradient
       id="snapshots-diff"
-      x1="-33.33333333333334%"
-      x2="66.66666666666666%"
+      x1="-100%"
+      x2="0%"
       y1={0}
       y2={0}
     >
@@ -230,8 +230,8 @@ exports[`ContentLoader snapshots renders correctly with viewBox defined and size
     </ClipPath>
     <LinearGradient
       id="snapshots-diff"
-      x1="-33.33333333333334%"
-      x2="66.66666666666666%"
+      x1="-100%"
+      x2="0%"
       y1={0}
       y2={0}
     >
@@ -314,8 +314,8 @@ exports[`ContentLoader snapshots renders correctly with viewBox empty 1`] = `
     </ClipPath>
     <LinearGradient
       id="snapshots-diff"
-      x1="-33.33333333333334%"
-      x2="66.66666666666666%"
+      x1="-100%"
+      x2="0%"
       y1={0}
       y2={0}
     >

--- a/src/native/__tests__/presets/__snapshots__/BulletListStyle.test.tsx.snap
+++ b/src/native/__tests__/presets/__snapshots__/BulletListStyle.test.tsx.snap
@@ -74,8 +74,8 @@ exports[`BulletListStyle renders correctly 1`] = `
     </ClipPath>
     <LinearGradient
       id="BulletListStyle-diff"
-      x1="-33.33333333333334%"
-      x2="66.66666666666666%"
+      x1="-100%"
+      x2="0%"
       y1={0}
       y2={0}
     >

--- a/src/native/__tests__/presets/__snapshots__/CodeStyle.test.tsx.snap
+++ b/src/native/__tests__/presets/__snapshots__/CodeStyle.test.tsx.snap
@@ -78,8 +78,8 @@ exports[`CodeStyle renders correctly 1`] = `
     </ClipPath>
     <LinearGradient
       id="CodeStyle-diff"
-      x1="-33.33333333333334%"
-      x2="66.66666666666666%"
+      x1="-100%"
+      x2="0%"
       y1={0}
       y2={0}
     >

--- a/src/native/__tests__/presets/__snapshots__/FacebookStyle.test.tsx.snap
+++ b/src/native/__tests__/presets/__snapshots__/FacebookStyle.test.tsx.snap
@@ -62,8 +62,8 @@ exports[`FacebookStyle renders correctly 1`] = `
     </ClipPath>
     <LinearGradient
       id="FacebookStyle-diff"
-      x1="-33.33333333333334%"
-      x2="66.66666666666666%"
+      x1="-100%"
+      x2="0%"
       y1={0}
       y2={0}
     >

--- a/src/native/__tests__/presets/__snapshots__/InstagramStyle.test.tsx.snap
+++ b/src/native/__tests__/presets/__snapshots__/InstagramStyle.test.tsx.snap
@@ -51,8 +51,8 @@ exports[`InstagramStyle renders correctly 1`] = `
     </ClipPath>
     <LinearGradient
       id="InstagramStyle-diff"
-      x1="-33.33333333333334%"
-      x2="66.66666666666666%"
+      x1="-100%"
+      x2="0%"
       y1={0}
       y2={0}
     >

--- a/src/native/__tests__/presets/__snapshots__/ListStyle.test.tsx.snap
+++ b/src/native/__tests__/presets/__snapshots__/ListStyle.test.tsx.snap
@@ -70,8 +70,8 @@ exports[`ListStyle renders correctly 1`] = `
     </ClipPath>
     <LinearGradient
       id="ListStyle-diff"
-      x1="-33.33333333333334%"
-      x2="66.66666666666666%"
+      x1="-100%"
+      x2="0%"
       y1={0}
       y2={0}
     >


### PR DESCRIPTION
Set the proper value of the initial position in the Native implementation. It ended up with an unexpected style in the very first frame. 

Closes #221