### PR TITLE
fix: cleanup native SVG animations

### DIFF
--- a/src/native/Svg.tsx
+++ b/src/native/Svg.tsx
@@ -32,6 +32,8 @@ class NativeSvg extends Component<IContentLoaderProps> {
 
   idGradient = `${this.fixedId}-animated-diff`
 
+  unmounted = false
+
   setAnimation = () => {
     // props.speed is in seconds as it is compatible with web
     // convert to milliseconds
@@ -44,7 +46,7 @@ class NativeSvg extends Component<IContentLoaderProps> {
       duration: durMs,
       useNativeDriver: true,
     }).start(() => {
-      if (this.props.animate) {
+      if (!this.unmounted && this.props.animate) {
         this.animatedValue.setValue(-1)
         this.setAnimation()
       }
@@ -61,6 +63,10 @@ class NativeSvg extends Component<IContentLoaderProps> {
     if (!prevProps.animate && this.props.animate) {
       this.setAnimation()
     }
+  }
+
+  componentWillUnmount() {
+    this.unmounted = true
   }
 
   render() {

--- a/src/native/__tests__/ContentLoader.test.tsx
+++ b/src/native/__tests__/ContentLoader.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { Animated } from 'react-native'
 import * as renderer from 'react-test-renderer'
 import * as ShallowRenderer from 'react-test-renderer/shallow'
 
@@ -119,6 +120,32 @@ describe('ContentLoader', () => {
       // custom props
       expect(typeof propsFromFullField.rtl).toBe('boolean')
       expect(propsFromFullField.rtl).toBe(true)
+    })
+  })
+
+  describe('when using SVG', () => {
+    describe('cleanup', () => {
+      afterAll(() => {
+        jest.useRealTimers()
+      })
+
+      it('cleans up animations when unmounted', () => {
+        jest.useFakeTimers()
+        const animationSpy = jest.spyOn(Animated, 'timing')
+
+        const mockSpeed = 10
+        const { unmount } = renderer.create(
+          <ContentLoader animate={true} height={200} speed={mockSpeed}>
+            <Rect />
+          </ContentLoader>
+        )
+
+        jest.runTimersToTime(mockSpeed)
+        unmount()
+        jest.runTimersToTime(mockSpeed)
+
+        expect(animationSpy).toHaveBeenCalledTimes(1)
+      })
     })
   })
 })


### PR DESCRIPTION
## Summary
When using native SVG which is currently animating and that component is unmounted without the animated prop ever becoming false, then the animation, which works recursively, is not cleaned up and will continue in the background. This change breaks the recursion loop when the component is unmounted.

This was found while running detox tests on a React Native application - this was causing the synchronisation engine to wait forever for the never-ending animation.

## Related Issue #[issue number]
(Possibly) https://github.com/danilowoz/react-content-loader/issues/125

## Any Breaking Changes
None

## Checklist
- [x] Are all the test cases passing?
- [] If any new feature has been added, then are the test cases updated/added?
- [] Has the documentation been updated for the proposed change, if required?