### PR TITLE
fix(web/svg.tsx): remove role=presentation from defs element.

### DIFF
--- a/src/web/Svg.tsx
+++ b/src/web/Svg.tsx
@@ -47,7 +47,7 @@ const SVG: React.FC<IContentLoaderProps> = ({
         style={{ fill: `url(${baseUrl}#${idGradient})` }}
       />
 
-      <defs role="presentation">
+      <defs>
         <clipPath id={idClip}>{children}</clipPath>
 
         <linearGradient id={idGradient}>

--- a/src/web/__tests__/__snapshots__/snapshots.test.tsx.snap
+++ b/src/web/__tests__/__snapshots__/snapshots.test.tsx.snap
@@ -26,9 +26,7 @@ exports[`ContentLoader snapshots renders correctly the basic version 1`] = `
     x="0"
     y="0"
   />
-  <defs
-    role="presentation"
-  >
+  <defs>
     <clipPath
       id="snapshots-diff"
     >
@@ -146,9 +144,7 @@ exports[`ContentLoader snapshots renders correctly with viewBox defined 1`] = `
     x="0"
     y="0"
   />
-  <defs
-    role="presentation"
-  >
+  <defs>
     <clipPath
       id="snapshots-diff"
     >
@@ -268,9 +264,7 @@ exports[`ContentLoader snapshots renders correctly with viewBox defined and size
     x="0"
     y="0"
   />
-  <defs
-    role="presentation"
-  >
+  <defs>
     <clipPath
       id="snapshots-diff"
     >
@@ -388,9 +382,7 @@ exports[`ContentLoader snapshots renders correctly with viewBox empty 1`] = `
     x="0"
     y="0"
   />
-  <defs
-    role="presentation"
-  >
+  <defs>
     <clipPath
       id="snapshots-diff"
     >

--- a/src/web/__tests__/presets/__snapshots__/BulletListStyle.test.tsx.snap
+++ b/src/web/__tests__/presets/__snapshots__/BulletListStyle.test.tsx.snap
@@ -26,9 +26,7 @@ exports[`BulletListStyle renders correctly 1`] = `
     x="0"
     y="0"
   />
-  <defs
-    role="presentation"
-  >
+  <defs>
     <clipPath
       id="BulletListStyle-diff"
     >

--- a/src/web/__tests__/presets/__snapshots__/CodeStyle.test.tsx.snap
+++ b/src/web/__tests__/presets/__snapshots__/CodeStyle.test.tsx.snap
@@ -26,9 +26,7 @@ exports[`CodeStyle renders correctly 1`] = `
     x="0"
     y="0"
   />
-  <defs
-    role="presentation"
-  >
+  <defs>
     <clipPath
       id="CodeStyle-diff"
     >

--- a/src/web/__tests__/presets/__snapshots__/FacebookStyle.test.tsx.snap
+++ b/src/web/__tests__/presets/__snapshots__/FacebookStyle.test.tsx.snap
@@ -26,9 +26,7 @@ exports[`FacebookStyle renders correctly 1`] = `
     x="0"
     y="0"
   />
-  <defs
-    role="presentation"
-  >
+  <defs>
     <clipPath
       id="FacebookStyle-diff"
     >

--- a/src/web/__tests__/presets/__snapshots__/InstagramStyle.test.tsx.snap
+++ b/src/web/__tests__/presets/__snapshots__/InstagramStyle.test.tsx.snap
@@ -26,9 +26,7 @@ exports[`InstagramStyle renders correctly 1`] = `
     x="0"
     y="0"
   />
-  <defs
-    role="presentation"
-  >
+  <defs>
     <clipPath
       id="InstagramStyle-diff"
     >

--- a/src/web/__tests__/presets/__snapshots__/ListStyle.test.tsx.snap
+++ b/src/web/__tests__/presets/__snapshots__/ListStyle.test.tsx.snap
@@ -26,9 +26,7 @@ exports[`ListStyle renders correctly 1`] = `
     x="0"
     y="0"
   />
-  <defs
-    role="presentation"
-  >
+  <defs>
     <clipPath
       id="ListStyle-diff"
     >


### PR DESCRIPTION
## Summary
In this section, you should give the overview of the problem and the proposed changes.

In using this repo more prevalently within our site and trying to maintain WCAG2AA compliance, we noticed an increase in accessibility errors due to `role="presentation"` being included on the `<defs>` element. 
<img width="858" alt="Screen Shot 2021-04-05 at 11 59 08 AM" src="https://user-images.githubusercontent.com/2632939/113600987-64cc1a80-9606-11eb-9bdf-b50ad204b7fc.png">

In doing some research on this, I've come to the conclusion that `role="presentation"` is not needed to explicitly hide the `<defs>` element for accessibility reasons. Just adding `role="presentation"` to the `<rect>` element is sufficient enough to do so since the `<rect>` element is what is referencing the elements within `<defs>`.

I tested this using [Axe](https://github.com/dequelabs/axe-core) and [Pa11y](https://github.com/pa11y/pa11y) as well as using the VoiceOver screen reader utility in MacOS. 

## Related Issue #[issue number]
If this PR is fixing any issue, then please include - Related Issue #[issue number]

## Any Breaking Changes
If this PR is introducing any breaking changes then mention them in this section.

## Checklist
- [x] Are all the test cases passing?
- [] If any new feature has been added, then are the test cases updated/added?
- [] Has the documentation been updated for the proposed change, if required?