### PR TITLE
fix(svg): migrate defaultProps to default parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,6 @@
         "husky": "3.1.0",
         "jest": "24.9.0",
         "metro-react-native-babel-preset": "0.57.0",
-        "nan": "^2.15.0",
         "prettier": "1.19.1",
         "react": "16.9.0",
         "react-dom": "16.12.0",
@@ -17561,30 +17560,34 @@
     },
     "node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -17592,15 +17595,17 @@
     },
     "node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -17608,66 +17613,75 @@
     },
     "node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -17677,24 +17691,27 @@
     },
     "node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
     },
     "node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -17708,9 +17725,10 @@
     },
     "node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -17728,15 +17746,17 @@
     },
     "node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -17746,18 +17766,20 @@
     },
     "node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -17765,24 +17787,27 @@
     },
     "node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -17792,15 +17817,17 @@
     },
     "node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -17810,15 +17837,17 @@
     },
     "node_modules/fsevents/node_modules/minimist": {
       "version": "1.2.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -17826,9 +17855,10 @@
     },
     "node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
@@ -17836,9 +17866,10 @@
     "node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.3",
       "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -17848,15 +17879,17 @@
     },
     "node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/needle": {
       "version": "2.3.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -17871,9 +17904,10 @@
     },
     "node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -17892,9 +17926,10 @@
     },
     "node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -17905,24 +17940,27 @@
     },
     "node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.8",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1",
@@ -17931,9 +17969,10 @@
     },
     "node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -17943,54 +17982,60 @@
     },
     "node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -17998,24 +18043,27 @@
     },
     "node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -18028,9 +18076,10 @@
     },
     "node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.7",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -18043,9 +18092,10 @@
     },
     "node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -18055,57 +18105,65 @@
     },
     "node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -18117,9 +18175,10 @@
     },
     "node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -18129,18 +18188,20 @@
     },
     "node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -18156,30 +18217,34 @@
     },
     "node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -50309,22 +50374,26 @@
         "abbrev": {
           "version": "1.1.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -50333,12 +50402,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -50347,32 +50418,38 @@
         "chownr": {
           "version": "1.1.4",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "debug": {
           "version": "3.2.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -50380,22 +50457,26 @@
         "deep-extend": {
           "version": "0.6.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "delegates": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.6.0"
           }
@@ -50403,12 +50484,14 @@
         "fs.realpath": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -50423,7 +50506,8 @@
         "glob": {
           "version": "7.1.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -50436,12 +50520,14 @@
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
@@ -50449,7 +50535,8 @@
         "ignore-walk": {
           "version": "3.0.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minimatch": "^3.0.4"
           }
@@ -50457,7 +50544,8 @@
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -50466,17 +50554,20 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -50484,12 +50575,14 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -50497,12 +50590,14 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -50511,7 +50606,8 @@
         "minizlib": {
           "version": "1.3.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minipass": "^2.9.0"
           }
@@ -50519,7 +50615,8 @@
         "mkdirp": {
           "version": "0.5.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -50527,12 +50624,14 @@
         "ms": {
           "version": "2.1.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "needle": {
           "version": "2.3.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
@@ -50542,7 +50641,8 @@
         "node-pre-gyp": {
           "version": "0.14.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
@@ -50559,7 +50659,8 @@
         "nopt": {
           "version": "4.0.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -50568,7 +50669,8 @@
         "npm-bundled": {
           "version": "1.1.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
@@ -50576,12 +50678,14 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1",
@@ -50591,7 +50695,8 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -50602,17 +50707,20 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -50620,17 +50728,20 @@
         "os-homedir": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -50639,17 +50750,20 @@
         "path-is-absolute": {
           "version": "1.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -50660,7 +50774,8 @@
         "readable-stream": {
           "version": "2.3.7",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -50674,7 +50789,8 @@
         "rimraf": {
           "version": "2.7.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -50682,37 +50798,44 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "sax": {
           "version": "1.2.4",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "semver": {
           "version": "5.7.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -50720,7 +50843,8 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -50730,7 +50854,8 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -50738,12 +50863,14 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "tar": {
           "version": "4.4.13",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -50757,12 +50884,14 @@
         "util-deprecate": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
           "bundled": true,
-          "extraneous": true,
+          "dev": true,
+          "optional": true,
           "requires": {
             "string-width": "^1.0.2 || 2"
           }
@@ -50770,12 +50899,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "extraneous": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/web/Svg.tsx
+++ b/src/web/Svg.tsx
@@ -4,23 +4,23 @@ import uid from '../shared/uid'
 import { IContentLoaderProps } from './'
 
 const SVG: React.FC<IContentLoaderProps> = ({
-  animate,
+  animate = true,
   animateBegin,
-  backgroundColor,
-  backgroundOpacity,
-  baseUrl,
+  backgroundColor = '#f5f6f7',
+  backgroundOpacity = 1,
+  baseUrl = '',
   children,
-  foregroundColor,
-  foregroundOpacity,
-  gradientRatio,
-  gradientDirection,
+  foregroundColor = '#eee',
+  foregroundOpacity = 1,
+  gradientRatio = 2,
+  gradientDirection = 'left-right',
   uniqueKey,
-  interval,
-  rtl,
-  speed,
-  style,
-  title,
-  beforeMask,
+  interval = 0.25,
+  rtl = false,
+  speed = 1.2,
+  style = {},
+  title = 'Loading...',
+  beforeMask = null,
   ...props
 }) => {
   const fixedId = uniqueKey || uid()
@@ -112,24 +112,6 @@ const SVG: React.FC<IContentLoaderProps> = ({
       </defs>
     </svg>
   )
-}
-
-SVG.defaultProps = {
-  animate: true,
-  backgroundColor: '#f5f6f7',
-  backgroundOpacity: 1,
-  baseUrl: '',
-  foregroundColor: '#eee',
-  foregroundOpacity: 1,
-  gradientRatio: 2,
-  gradientDirection: 'left-right',
-  id: null,
-  interval: 0.25,
-  rtl: false,
-  speed: 1.2,
-  style: {},
-  title: 'Loading...',
-  beforeMask: null,
 }
 
 export default SVG

--- a/src/web/__tests__/ContentLoader.test.tsx
+++ b/src/web/__tests__/ContentLoader.test.tsx
@@ -58,22 +58,15 @@ describe('ContentLoader', () => {
       </ContentLoader>
     )
 
-    const { props: propsFromEmpty } = noPropsComponent.getRenderOutput()
     const { props: propsFromFullfield } = withPropsComponent.getRenderOutput()
 
     it("`speed` is a number and it's used", () => {
-      // defaultProps
-      expect(typeof propsFromEmpty.speed).toBe('number')
-      expect(propsFromEmpty.speed).toBe(1.2)
       // custom props
       expect(typeof propsFromFullfield.speed).toBe('number')
       expect(propsFromFullfield.speed).toBe(10)
     })
 
     it("`interval` is a number and it's used", () => {
-      // defaultProps
-      expect(typeof propsFromEmpty.interval).toBe('number')
-      expect(propsFromEmpty.interval).toBe(0.25)
       // custom props
       expect(typeof propsFromFullfield.interval).toBe('number')
       expect(propsFromFullfield.interval).toBe(0.5)
@@ -92,63 +85,42 @@ describe('ContentLoader', () => {
     })
 
     it("`gradientRatio` is a number and it's used", () => {
-      // defaultProps
-      expect(typeof propsFromEmpty.gradientRatio).toBe('number')
-      expect(propsFromEmpty.gradientRatio).toBe(2)
       // custom props
       expect(typeof propsFromFullfield.gradientRatio).toBe('number')
       expect(propsFromFullfield.gradientRatio).toBe(0.5)
     })
 
     it("`gradientDirection` is a string and it's used", () => {
-      // defaultProps
-      expect(typeof propsFromEmpty.gradientDirection).toBe('string')
-      expect(propsFromEmpty.gradientDirection).toBe('left-right')
       // custom props
       expect(typeof propsFromFullfield.gradientDirection).toBe('string')
       expect(propsFromFullfield.gradientDirection).toBe('top-bottom')
     })
 
     it("`animate` is a boolean and it's used", () => {
-      // defaultProps
-      expect(typeof propsFromEmpty.animate).toBe('boolean')
-      expect(propsFromEmpty.animate).toBe(true)
       // custom props
       expect(typeof propsFromFullfield.animate).toBe('boolean')
       expect(propsFromFullfield.animate).toBe(false)
     })
 
     it("`backgroundColor` is a string and it's used", () => {
-      // defaultProps
-      expect(typeof propsFromEmpty.backgroundColor).toBe('string')
-      expect(propsFromEmpty.backgroundColor).toBe('#f5f6f7')
       // custom props
       expect(typeof propsFromFullfield.backgroundColor).toBe('string')
       expect(propsFromFullfield.backgroundColor).toBe('#000')
     })
 
     it("`foregroundColor` is a string and it's used", () => {
-      // defaultProps
-      expect(typeof propsFromEmpty.foregroundColor).toBe('string')
-      expect(propsFromEmpty.foregroundColor).toBe('#eee')
       // custom props
       expect(typeof propsFromFullfield.foregroundColor).toBe('string')
       expect(propsFromFullfield.foregroundColor).toBe('#fff')
     })
 
     it("`backgroundOpacity` is a number and it's used", () => {
-      // defaultProps
-      expect(typeof propsFromEmpty.backgroundOpacity).toBe('number')
-      expect(propsFromEmpty.backgroundOpacity).toBe(1)
       // custom props
       expect(typeof propsFromFullfield.backgroundOpacity).toBe('number')
       expect(propsFromFullfield.backgroundOpacity).toBe(0.06)
     })
 
     it("`foregroundOpacity` is a number and it's used", () => {
-      // defaultProps
-      expect(typeof propsFromEmpty.foregroundOpacity).toBe('number')
-      expect(propsFromEmpty.foregroundOpacity).toBe(1)
       // custom props
       expect(typeof propsFromFullfield.foregroundOpacity).toBe('number')
       expect(propsFromFullfield.foregroundOpacity).toBe(0.12)
@@ -161,60 +133,41 @@ describe('ContentLoader', () => {
     })
 
     it("`style` is an object and it's used", () => {
-      // defaultProps
-      expect(propsFromEmpty.style).toMatchObject({})
       // custom props
       expect(propsFromFullfield.style).toMatchObject({ marginBottom: '10px' })
     })
 
     it("`rtl` is a boolean and it's used", () => {
-      // defaultProps
-      expect(typeof propsFromEmpty.rtl).toBe('boolean')
-      expect(propsFromEmpty.rtl).toBe(false)
       // custom props
       expect(typeof propsFromFullfield.rtl).toBe('boolean')
       expect(propsFromFullfield.rtl).toBe(true)
     })
 
     it("`title` is a string and it's used", () => {
-      // defaultProps
-      expect(typeof propsFromEmpty.title).toBe('string')
-      expect(propsFromEmpty.title).toBe('Loading...')
       // custom props
       expect(typeof propsFromFullfield.title).toBe('string')
       expect(propsFromFullfield.title).toBe('My custom loading title')
     })
 
     it("`baseUrl` is a string and it's used", () => {
-      // defaultProps
-      expect(typeof propsFromEmpty.baseUrl).toBe('string')
-      expect(propsFromEmpty.baseUrl).toBe('')
       // custom props
       expect(typeof propsFromFullfield.baseUrl).toBe('string')
       expect(propsFromFullfield.baseUrl).toBe('/mypage')
     })
 
     it("`uniqueKey` is a string and it's used", () => {
-      // defaultProps
-      expect(typeof propsFromEmpty.uniqueKey).toBe('undefined')
-      expect(propsFromEmpty.uniqueKey).toBe(undefined)
       // custom props
       expect(typeof propsFromFullfield.uniqueKey).toBe('string')
       expect(propsFromFullfield.uniqueKey).toBe('my-id')
     })
 
     it("`beforeMask` is a JSX Element and it's used", () => {
-      // defaultProps
-      expect(typeof propsFromEmpty.beforeMask).toBe('object')
-      expect(propsFromEmpty.beforeMask).toBe(null)
       // custom props
       expect(typeof propsFromFullfield.beforeMask).toBe('object')
       expect(propsFromFullfield.beforeMask).toEqual(<rect />)
     })
 
     it("`animateBegin` is a string and it's used", () => {
-      // defaultProps
-      expect(propsFromEmpty.animateBegin).toBe(undefined)
       // custom props
       expect(typeof propsFromFullfield.animateBegin).toBe('string')
       expect(propsFromFullfield.animateBegin).toEqual('5s')

--- a/src/web/__tests__/__snapshots__/snapshots.test.tsx.snap
+++ b/src/web/__tests__/__snapshots__/snapshots.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`ContentLoader snapshots renders correctly the basic version 1`] = `
 <svg
   aria-labelledby="snapshots-aria"
-  id={null}
   role="img"
   style={Object {}}
   viewBox="0 0 476 124"
@@ -121,7 +120,6 @@ exports[`ContentLoader snapshots renders correctly the basic version 1`] = `
 exports[`ContentLoader snapshots renders correctly with beforeMask 1`] = `
 <svg
   aria-labelledby="snapshots-aria"
-  id={null}
   role="img"
   style={Object {}}
 >
@@ -205,7 +203,6 @@ exports[`ContentLoader snapshots renders correctly with beforeMask 1`] = `
 exports[`ContentLoader snapshots renders correctly with beforeMask 2`] = `
 <svg
   aria-labelledby="snapshots-aria"
-  id={null}
   role="img"
   style={Object {}}
 >
@@ -283,7 +280,6 @@ exports[`ContentLoader snapshots renders correctly with beforeMask 2`] = `
 exports[`ContentLoader snapshots renders correctly with viewBox defined 1`] = `
 <svg
   aria-labelledby="snapshots-aria"
-  id={null}
   role="img"
   style={Object {}}
   viewBox="0 0 100 100"
@@ -402,7 +398,6 @@ exports[`ContentLoader snapshots renders correctly with viewBox defined and size
 <svg
   aria-labelledby="snapshots-aria"
   height={100}
-  id={null}
   role="img"
   style={Object {}}
   viewBox="0 0 100 100"
@@ -521,7 +516,6 @@ exports[`ContentLoader snapshots renders correctly with viewBox defined and size
 exports[`ContentLoader snapshots renders correctly with viewBox empty 1`] = `
 <svg
   aria-labelledby="snapshots-aria"
-  id={null}
   role="img"
   style={Object {}}
   viewBox=""

--- a/src/web/__tests__/presets/__snapshots__/BulletListStyle.test.tsx.snap
+++ b/src/web/__tests__/presets/__snapshots__/BulletListStyle.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`BulletListStyle renders correctly 1`] = `
 <svg
   aria-labelledby="BulletListStyle-aria"
-  id={null}
   role="img"
   style={Object {}}
   viewBox="0 0 245 125"

--- a/src/web/__tests__/presets/__snapshots__/CodeStyle.test.tsx.snap
+++ b/src/web/__tests__/presets/__snapshots__/CodeStyle.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`CodeStyle renders correctly 1`] = `
 <svg
   aria-labelledby="CodeStyle-aria"
-  id={null}
   role="img"
   style={Object {}}
   viewBox="0 0 340 84"

--- a/src/web/__tests__/presets/__snapshots__/FacebookStyle.test.tsx.snap
+++ b/src/web/__tests__/presets/__snapshots__/FacebookStyle.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`FacebookStyle renders correctly 1`] = `
 <svg
   aria-labelledby="FacebookStyle-aria"
-  id={null}
   role="img"
   style={Object {}}
   viewBox="0 0 476 124"

--- a/src/web/__tests__/presets/__snapshots__/InstagramStyle.test.tsx.snap
+++ b/src/web/__tests__/presets/__snapshots__/InstagramStyle.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`InstagramStyle renders correctly 1`] = `
 <svg
   aria-labelledby="InstagramStyle-aria"
-  id={null}
   role="img"
   style={Object {}}
   viewBox="0 0 400 460"

--- a/src/web/__tests__/presets/__snapshots__/ListStyle.test.tsx.snap
+++ b/src/web/__tests__/presets/__snapshots__/ListStyle.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`ListStyle renders correctly 1`] = `
 <svg
   aria-labelledby="ListStyle-aria"
-  id={null}
   role="img"
   style={Object {}}
   viewBox="0 0 400 110"


### PR DESCRIPTION
defaultProps is deprecated and will be removed from function components

fix #298

## Summary

There's an error because this lib is using `defaultProps` for the `SVG.tsx` component. `defaultProps` are deprecated in function components.

<img width="1133" alt="CleanShot 2023-03-03 at 13 25 55@2x" src="https://user-images.githubusercontent.com/9285210/222719874-a7aba653-b0fb-4603-98b3-5a19245f7e83.png">

A simple fix is to migrate `defaultProps` to default JS parameters.

## Related Issue #[issue number]

#298 has been opened, thanks to @shehi for pointing out the file to update.

## Any Breaking Changes

There is no breaking changes.

## Checklist
- [x] Are all the test cases passing?
- [] If any new feature has been added, then are the test cases updated/added?
- [] Has the documentation been updated for the proposed change, if required?