### PR TITLE
Fix/remove optional title

### DIFF
--- a/src/web/Svg.tsx
+++ b/src/web/Svg.tsx
@@ -19,7 +19,7 @@ const SVG: React.FC<IContentLoaderProps> = ({
   rtl = false,
   speed = 1.2,
   style = {},
-  title = 'Loading...',
+  title = '',
   beforeMask = null,
   ...props
 }) => {

--- a/src/web/__tests__/__snapshots__/snapshots.test.tsx.snap
+++ b/src/web/__tests__/__snapshots__/snapshots.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`ContentLoader snapshots renders correctly the basic version 1`] = `
   <title
     id="snapshots-aria"
   >
-    Loading...
+    
   </title>
   <rect
     clipPath="url(#snapshots-diff)"
@@ -126,7 +126,7 @@ exports[`ContentLoader snapshots renders correctly with beforeMask 1`] = `
   <title
     id="snapshots-aria"
   >
-    Loading...
+    
   </title>
   <rect
     role="outline1"
@@ -209,7 +209,7 @@ exports[`ContentLoader snapshots renders correctly with beforeMask 2`] = `
   <title
     id="snapshots-aria"
   >
-    Loading...
+    
   </title>
   <rect
     clipPath="url(#snapshots-diff)"
@@ -287,7 +287,7 @@ exports[`ContentLoader snapshots renders correctly with viewBox defined 1`] = `
   <title
     id="snapshots-aria"
   >
-    Loading...
+    
   </title>
   <rect
     clipPath="url(#snapshots-diff)"
@@ -406,7 +406,7 @@ exports[`ContentLoader snapshots renders correctly with viewBox defined and size
   <title
     id="snapshots-aria"
   >
-    Loading...
+    
   </title>
   <rect
     clipPath="url(#snapshots-diff)"
@@ -523,7 +523,7 @@ exports[`ContentLoader snapshots renders correctly with viewBox empty 1`] = `
   <title
     id="snapshots-aria"
   >
-    Loading...
+    
   </title>
   <rect
     clipPath="url(#snapshots-diff)"

--- a/src/web/__tests__/presets/__snapshots__/BulletListStyle.test.tsx.snap
+++ b/src/web/__tests__/presets/__snapshots__/BulletListStyle.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`BulletListStyle renders correctly 1`] = `
   <title
     id="BulletListStyle-aria"
   >
-    Loading...
+    
   </title>
   <rect
     clipPath="url(#BulletListStyle-diff)"

--- a/src/web/__tests__/presets/__snapshots__/CodeStyle.test.tsx.snap
+++ b/src/web/__tests__/presets/__snapshots__/CodeStyle.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`CodeStyle renders correctly 1`] = `
   <title
     id="CodeStyle-aria"
   >
-    Loading...
+    
   </title>
   <rect
     clipPath="url(#CodeStyle-diff)"

--- a/src/web/__tests__/presets/__snapshots__/FacebookStyle.test.tsx.snap
+++ b/src/web/__tests__/presets/__snapshots__/FacebookStyle.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`FacebookStyle renders correctly 1`] = `
   <title
     id="FacebookStyle-aria"
   >
-    Loading...
+    
   </title>
   <rect
     clipPath="url(#FacebookStyle-diff)"

--- a/src/web/__tests__/presets/__snapshots__/InstagramStyle.test.tsx.snap
+++ b/src/web/__tests__/presets/__snapshots__/InstagramStyle.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`InstagramStyle renders correctly 1`] = `
   <title
     id="InstagramStyle-aria"
   >
-    Loading...
+    
   </title>
   <rect
     clipPath="url(#InstagramStyle-diff)"

--- a/src/web/__tests__/presets/__snapshots__/ListStyle.test.tsx.snap
+++ b/src/web/__tests__/presets/__snapshots__/ListStyle.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`ListStyle renders correctly 1`] = `
   <title
     id="ListStyle-aria"
   >
-    Loading...
+    
   </title>
   <rect
     clipPath="url(#ListStyle-diff)"


### PR DESCRIPTION
## Summary
-Updated the optional prop 'title' to have an empty string as the default value.
-Updated tests to pass the updated ui.
Currently, ContentLoader shows "Loading..." by default. but sometimes it's necessary to have no titles. 

## Related Issue #[issue number]
#309 

## Any Breaking Changes
had to update tests also, as its a visible change.

## Checklist
- [] Are all the test cases passing?
- [] If any new feature has been added, then are the test cases updated/added?
- [] Has the documentation been updated for the proposed change, if required?