### PR TITLE
fix(hydration): use `useId` for dom variant

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "typescript": "5.4.2"
   },
   "peerDependencies": {
-    "react": ">=16.0.0"
+    "react": ">=18.0.0"
   },
   "husky": {
     "hooks": {

--- a/src/web/Svg.tsx
+++ b/src/web/Svg.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 
-import uid from '../shared/uid'
 import { IContentLoaderProps } from './'
 
 const SVG: React.FC<IContentLoaderProps> = ({
@@ -20,7 +19,8 @@ const SVG: React.FC<IContentLoaderProps> = ({
   beforeMask = null,
   ...props
 }) => {
-  const fixedId = uniqueKey || uid()
+  let fixedId = React.useId()
+  if (uniqueKey) fixedId = uniqueKey
   const idClip = `${fixedId}-diff`
   const idGradient = `${fixedId}-animated-diff`
   const idAria = `${fixedId}-aria`


### PR DESCRIPTION
## Summary
Next.js (and other SSR frameworks) frequently logs warnings about mismatched `id` attributes between the server and client.
![image](https://github.com/user-attachments/assets/71a7a8c7-4d80-4c79-abfb-5564eeac7c0d)  
To address this issue, the React team introduced the [`useId`](https://react.dev/reference/react/useId) hook, specifically designed to prevent such mismatches.

## Breaking Changes
Since `useId` was introduced in React 18, I updated the peer dependency to require React 18 or newer. Given that React 18 was released over two years ago, it seems reasonable for this library's new version to discontinue support for older React versions.

## Checklist

- [x] Are all the test cases passing? (only for web version, native test failing even in master, and I change nothing for native)
- [x] If any new feature has been added, then are the test cases updated/added? (no new features)
- [x] Has the documentation been updated for the proposed change, if required? (not required)