### PR TITLE
fix: JSX namespace usage without import

### DIFF
--- a/src/web/index.ts
+++ b/src/web/index.ts
@@ -1,4 +1,4 @@
-import { SVGAttributes } from 'react'
+import { SVGAttributes, ReactElement } from 'react'
 
 import ContentLoader from './ContentLoader'
 
@@ -14,7 +14,7 @@ export interface IContentLoaderProps extends SVGAttributes<SVGElement> {
   speed?: number
   title?: string
   uniqueKey?: string
-  beforeMask?: JSX.Element
+  beforeMask?: ReactElement
 }
 
 export { default as Facebook } from './presets/FacebookStyle'


### PR DESCRIPTION
## Summary
In this section, you should give the overview of the problem and the proposed changes.
A JSX reference is present, without the necessary import (necessary in latest react + ts)

## Related Issue #[issue number]
If this PR is fixing any issue, then please include - Related Issue #[issue number]
#333 

## Any Breaking Changes
If this PR is introducing any breaking changes then mention them in this section.

## Checklist
- [] Are all the test cases passing?
- [] If any new feature has been added, then are the test cases updated/added?
- [] Has the documentation been updated for the proposed change, if required?